### PR TITLE
Add a paths-ignore yml field that will be used for skip checks workflow

### DIFF
--- a/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TriggerEvent.cs
+++ b/ADotNet/Models/Pipelines/GithubPipelines/DotNets/TriggerEvent.cs
@@ -20,5 +20,12 @@ namespace ADotNet.Models.Pipelines.GithubPipelines.DotNets
             DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections,
             Description = "Which files should trigger the workflow")]
         public string[] Paths { get; set; } = Array.Empty<string>();
+
+        [YamlMember(
+            Alias = "paths-ignore",
+            ScalarStyle = ScalarStyle.Folded,
+            DefaultValuesHandling = DefaultValuesHandling.OmitEmptyCollections,
+            Description = "Which files should NOT trigger the workflow")]
+        public string[] PathsIgnore { get; set; }
     }
 }

--- a/AdoNet.Tests.Console/Program.cs
+++ b/AdoNet.Tests.Console/Program.cs
@@ -120,7 +120,8 @@ namespace ADotNet.Tests.Console
                 {
                     Push = new PushEvent
                     {
-                        Branches = new string[] { "master" }
+                        Branches = new string[] { "master" },
+                        PathsIgnore = new string[] { "*.md" }
                     },
                     PullRequest = new PullRequestEvent
                     {


### PR DESCRIPTION
The introduction of this Property will allow us to better manage which workflows are triggered by which exact paths. Example usage:
paths-ignore : ["*.md"] should in general skip any workflow runs when for example only the Readme has been updated